### PR TITLE
Branding changes

### DIFF
--- a/src/Admin/MPAIAdminMenu.php
+++ b/src/Admin/MPAIAdminMenu.php
@@ -131,8 +131,8 @@ class MPAIAdminMenu extends AbstractService {
         // Add the main settings page
         add_submenu_page(
             $this->parent_menu_slug,
-            __('AI Assistant', 'memberpress-ai-assistant'),
-            __('AI Assistant', 'memberpress-ai-assistant'),
+            __('Copilot', 'memberpress-copilot'),
+            __('Copilot', 'memberpress-copilot'),
             'manage_options',
             $this->menu_slug,
             [$this, 'render_settings_page']
@@ -141,8 +141,8 @@ class MPAIAdminMenu extends AbstractService {
         // Add the welcome page (hidden from menu)
         add_submenu_page(
             null, // Hidden from menu
-            __('AI Assistant Welcome', 'memberpress-ai-assistant'),
-            __('AI Assistant Welcome', 'memberpress-ai-assistant'),
+            __('Copilot Welcome', 'memberpress-copilot'),
+            __('Copilot Welcome', 'memberpress-copilot'),
             'manage_options',
             'mpai-welcome',
             [$this, 'render_welcome_page']
@@ -158,8 +158,8 @@ class MPAIAdminMenu extends AbstractService {
      */
     protected function register_top_level_menu(): void {
         add_menu_page(
-            __('MemberPress AI', 'memberpress-ai-assistant'),
-            __('MemberPress AI', 'memberpress-ai-assistant'),
+            __('MemberPress Copilot', 'memberpress-copilot'),
+            __('MemberPress Copilot', 'memberpress-copilot'),
             'manage_options',
             $this->menu_slug,
             [$this, 'render_settings_page'],
@@ -170,8 +170,8 @@ class MPAIAdminMenu extends AbstractService {
         // Add the welcome page (hidden from menu)
         add_submenu_page(
             null, // Hidden from menu
-            __('AI Assistant Welcome', 'memberpress-ai-assistant'),
-            __('AI Assistant Welcome', 'memberpress-ai-assistant'),
+            __('Copilot Welcome', 'memberpress-copilot'),
+            __('Copilot Welcome', 'memberpress-copilot'),
             'manage_options',
             'mpai-welcome',
             [$this, 'render_welcome_page']

--- a/templates/chat-interface.php
+++ b/templates/chat-interface.php
@@ -54,7 +54,7 @@ if (!defined('ABSPATH')) {
         </div>
         <div class="mpai-chat-footer">
             <span class="mpai-chat-powered-by">
-                <?php esc_html_e('Powered by MemberPress AI', 'memberpress-copilot'); ?>
+                <?php esc_html_e('Powered by MemberPress Copilot', 'memberpress-copilot'); ?>
             </span>
             <div class="mpai-chat-footer-actions">
                 <a href="#" id="mpai-clear-conversation" class="mpai-clear-conversation">


### PR DESCRIPTION
All user-facing references to "MemberPress AI Assistant" have now been successfully updated to "MemberPress Copilot". The
  text domains have also been updated from 'memberpress-ai-assistant' to 'memberpress-copilot' to ensure proper
  internationalization.