### PR TITLE
Fix clear conversation functionality

### DIFF
--- a/assets/js/chat/core/api-client.js
+++ b/assets/js/chat/core/api-client.js
@@ -181,12 +181,12 @@ class APIClient {
       this._abortControllers.set(requestId, abortController);
       
       // Prepare the request data for clearing conversation
+      // Send the parameters that the server expects: clear_history=true and a dummy message
       const data = {
-        action: 'clear_conversation'
+        message: 'clear_conversation', // Dummy message to satisfy REST endpoint validation
+        clear_history: true,
+        conversation_id: null // Will be set by the server logic if needed
       };
-      
-      // DEBUG: Log the data being sent for clear conversation
-      console.log('[MPAI Debug] clearConversation - Request data:', data);
       
       // Make the API request to clear conversation
       const response = await this._makeRequest('clear', data, {

--- a/src/ChatInterface.php
+++ b/src/ChatInterface.php
@@ -679,26 +679,12 @@ class ChatInterface {
      * @return \WP_REST_Response The REST response
      */
     public function processChatRequest($request) {
-        // DEBUG: Log all incoming request parameters
-        $all_params = $request->get_params();
-        \MemberpressAiAssistant\Utilities\LoggingUtility::debug('[MPAI Debug] processChatRequest - All request parameters:', $all_params);
-        
         // Get request parameters
         $message = $request->get_param('message');
         $conversation_id = $request->get_param('conversation_id');
         $load_history = (bool)$request->get_param('load_history');
         $clear_history = (bool)$request->get_param('clear_history');
         $user_logged_in = (bool)$request->get_param('user_logged_in');
-        $action = $request->get_param('action'); // DEBUG: Check for action parameter
-        
-        // DEBUG: Log specific parameter values
-        \MemberpressAiAssistant\Utilities\LoggingUtility::debug('[MPAI Debug] processChatRequest - Parameter analysis:', [
-            'message' => $message,
-            'clear_history' => $clear_history,
-            'action' => $action,
-            'has_message' => !empty($message),
-            'is_clear_request' => $action === 'clear_conversation' || $clear_history
-        ]);
         
         // Check if this is a blog post request
         $isBlogPostRequest = false;
@@ -769,29 +755,6 @@ class ChatInterface {
                 ]);
             }
             
-            // DEBUG: Check if this is a clear conversation request via action parameter
-            if ($action === 'clear_conversation') {
-                \MemberpressAiAssistant\Utilities\LoggingUtility::debug('[MPAI Debug] Clear conversation request detected via action parameter', [
-                    'action' => $action,
-                    'user_id' => $user_id,
-                    'conversation_id' => $conversation_id,
-                    'clear_history_param' => $clear_history
-                ]);
-                
-                // Handle clear conversation request
-                if ($user_id > 0) {
-                    \MemberpressAiAssistant\Utilities\LoggingUtility::info('Clearing conversation via action parameter for user: ' . $user_id);
-                    $this->clearUserConversationHistory($user_id, $conversation_id);
-                    
-                    // Return success response
-                    return rest_ensure_response([
-                        'status' => 'success',
-                        'message' => 'Conversation cleared successfully',
-                        'conversation_id' => null,
-                        'timestamp' => time()
-                    ]);
-                }
-            }
             
             // For logged-in users, try to get their conversation ID from user metadata
             if ($user_id > 0 && empty($conversation_id)) {


### PR DESCRIPTION
The clear conversation functionality now works correctly without the 400 Bad Request error. The fix maintains compatibility with the existing server-side logic while ensuring all required REST API parameters are provided.